### PR TITLE
feature/AB#125481

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ Examples of how to use this _markdown_ cand be found here [Keep a CHANGELOG](htt
 
 ## Unreleased
 ### Added
-- support to querystring field.
+- Support to querystring field.
 
 ## [0.4.0](https://github.com/stone-payments/kong-plugin-url-rewrite/tree/v0.4.0) - 2018-12-26
 ### Added
-- support to parameter replacing when rewriting URL.
+- Support to parameter replacing when rewriting URL.
 
 ## [0.3.0](https://github.com/stone-payments/kong-plugin-url-rewrite/tree/v0.3.0) - 2018-10-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All changes made on any release of this project should be commented on high leve
 Document model based on [Semantic Versioning](http://semver.org/).
 Examples of how to use this _markdown_ cand be found here [Keep a CHANGELOG](http://keepachangelog.com/).
 
+
+## Unreleased
+### Added
+- support to querystring field.
+
 ## [0.4.0](https://github.com/stone-payments/kong-plugin-url-rewrite/tree/v0.4.0) - 2018-12-26
 ### Added
 - support to parameter replacing when rewriting URL.

--- a/url-rewrite/schema.lua
+++ b/url-rewrite/schema.lua
@@ -1,6 +1,7 @@
 return {
   no_consumer = true,
   fields = {
-    url = {required = true, type = "string"}
+    url = {required = true, type = "string"},
+    query_string = {required = false, type = "table"}
   }
 }

--- a/url-rewrite/spec/handler_spec.lua
+++ b/url-rewrite/spec/handler_spec.lua
@@ -8,6 +8,10 @@ local ngx =  {
       router_matches = {
         uri_captures = {}
       }
+    },
+    req = {
+      get_uri_args = spy.new(function() return {} end),
+      set_uri_args = spy.new(function() end)
     }
 }
 
@@ -52,5 +56,23 @@ describe("TestHandler", function()
     local result = resolveUrlParams(iter, mockUrl)
 
     assert.equal("url/123456/test", result)
+  end)
+
+  it("should add querystring params when schema has query_string field", function()
+    URLRewriter:new()
+    ngx.ctx.router_matches.uri_captures["code_parameter"] = "123456"
+    config = {
+        url = "new_url",
+        query_string = {
+          "code_parameter=<code_parameter>",
+          "parameter2=abcdef",
+        }
+    }
+    URLRewriter:access(config)
+    local expected = {
+      code_parameter = "123456",
+      parameter2 = "abcdef",
+    }
+    assert.spy(ngx.req.set_uri_args).was_called_with(expected)
   end)
 end)


### PR DESCRIPTION
example:
```
"config": {
   "url": "/api/v2/loans",
   "query_string": [
       "document=<document>"
   ]
}
```