### PR TITLE
:bug: fixed resolveUrlParams function with special character in url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All changes made on any release of this project should be commented on high leve
 Document model based on [Semantic Versioning](http://semver.org/).
 Examples of how to use this _markdown_ cand be found here [Keep a CHANGELOG](http://keepachangelog.com/).
 
+## Unreleased
+### Fixed
+- [resolveUrlParams function with special character in url](https://dev.azure.com/stonepagamentos/frt-portal/_workitems/edit/132078)
 
 ## [0.5.0](https://github.com/stone-payments/kong-plugin-url-rewrite/tree/v0.5.0) - 2020-03-05
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:stretch
+
+RUN apt-get update
+
+RUN apt-get install -y \
+  lua5.2 \
+  liblua5.2-dev \
+  luarocks \
+  git \
+  libssl1.0-dev \
+  make
+
+ADD Makefile .
+RUN make setup
+
+ADD kong-plugin-url-rewrite-*.rockspec .

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ PROJECT_FOLDER = url-rewrite
 LUA_PROJECT = kong-plugin-url-rewrite
 
 setup:
-	cd $(PROJECT_FOLDER)
 	@for rock in $(DEV_ROCKS) ; do \
 		if luarocks list --porcelain $$rock | grep -q "installed" ; then \
 			echo $$rock already installed, skipping ; \
@@ -14,7 +13,6 @@ setup:
 	done;
 
 check:
-	cd $(PROJECT_FOLDER)
 	@for rock in $(DEV_ROCKS) ; do \
 		if luarocks list --porcelain $$rock | grep -q "installed" ; then \
 			echo $$rock is installed ; \

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ curl -X POST http://kong:8001/routes/{route_id}/plugins \
 - route_id: the id of the Route that this plugin configuration will target.
 - config.url: the url where you want kong to execute the request.
 
+## Developing
+
+### In docker
+
+```bash
+docker build . -t kong-plugin-url-rewrite-dev
+docker run -it -v ${PWD}/url-rewrite:/url-rewrite kong-plugin-url-rewrite-dev bash
+```
+
 ## Credits
 
 made with :heart: by Stone Payments

--- a/url-rewrite/handler.lua
+++ b/url-rewrite/handler.lua
@@ -19,7 +19,8 @@ end
 function resolveUrlParams(requestParams, url)
   for paramValue in requestParams do
     local requestParamValue = ngx.ctx.router_matches.uri_captures[paramValue]
-    requestParamValue = requestParamValue:gsub("%%", "%%%%")
+    if type(requestParamValue) == string
+      requestParamValue = requestParamValue:gsub("%%", "%%%%")
     url = url:gsub("<" .. paramValue .. ">", requestParamValue)
   end
   return url

--- a/url-rewrite/handler.lua
+++ b/url-rewrite/handler.lua
@@ -19,6 +19,7 @@ end
 function resolveUrlParams(requestParams, url)
   for paramValue in requestParams do
     local requestParamValue = ngx.ctx.router_matches.uri_captures[paramValue]
+    requestParamValue = requestParamValue:gsub("%%", "%%%%")
     url = url:gsub("<" .. paramValue .. ">", requestParamValue)
   end
   return url

--- a/url-rewrite/handler.lua
+++ b/url-rewrite/handler.lua
@@ -19,8 +19,9 @@ end
 function resolveUrlParams(requestParams, url)
   for paramValue in requestParams do
     local requestParamValue = ngx.ctx.router_matches.uri_captures[paramValue]
-    if type(requestParamValue) == string
+    if type(requestParamValue) == 'string' then
       requestParamValue = requestParamValue:gsub("%%", "%%%%")
+    end
     url = url:gsub("<" .. paramValue .. ">", requestParamValue)
   end
   return url

--- a/url-rewrite/spec/handler_spec.lua
+++ b/url-rewrite/spec/handler_spec.lua
@@ -57,6 +57,18 @@ describe("TestHandler", function()
 
     assert.equal("url/123456/test", result)
   end)
+  
+  it("should replace url params with special character", function()
+    URLRewriter:new()
+    local mockUrl = "url/<param1>/<param2>"
+    local iter = getRequestUrlParams(mockUrl)
+    ngx.ctx.router_matches.uri_captures["param1"] = "test%23special%2fcharacter"
+    ngx.ctx.router_matches.uri_captures["param2"] = "test%2bspecial%3fcharacter"
+
+    local result = resolveUrlParams(iter, mockUrl)
+
+    assert.equal("url/test%23special%2fcharacter/test%2bspecial%3fcharacter", result)
+  end)
 
   it("should add querystring params when schema has query_string field", function()
     URLRewriter:new()


### PR DESCRIPTION
Resolve o problema de aceitar o caracter % como como parâmetro nas urls do kong, foi necessario para resolver o problema da passagem de emails com o caracter + nas urls do endpoint do chaves (%2B), o comando gsub entende o % como caracter de escape, portando foi necessário um tratamento prévio do conteúdo dos parâmetros do tipo string antes de realizar o replace na URL