### PR TITLE
feat: Adds service path to upstream URL when it is present

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -18,20 +18,22 @@ stages:
         - job: Build
           steps:
           - bash: |
-              sudo apt install lua5.3
-              sudo apt-get install liblua5.3-dev
+              sudo apt install -y lua5.3
+              sudo apt install -y liblua5.3-dev
 
               wget https://luarocks.org/releases/luarocks-3.3.1.tar.gz
               tar zxpf luarocks-3.3.1.tar.gz
               cd luarocks-3.3.1 && ./configure --with-lua-include=/usr/include/lua5.3 \
                 && make && sudo make install
+              cd .. && rm -rf luarocks-3.3.1 && rm luarocks-3.3.1.tar.gz
             displayName: Install Lua and Luarocks
 
           - bash: |
-              sudo apt-get install libssl-dev
+              sudo apt install -y libssl-dev
               wget https://download.konghq.com/gateway-2.x-ubuntu-bionic/pool/all/k/kong/kong_2.6.0_amd64.deb
-              sudo apt-get install ./kong_2.6.0_amd64.deb
-            displayName: Installing kong
+              sudo apt install -y ./kong_2.6.0_amd64.deb
+              rm kong_2.6.0_amd64.deb
+            displayName: Install kong
 
           - task: Bash@3
             displayName: 'Prepare'

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -1,9 +1,9 @@
 pr:
-- master
+- main
 - develop
 
 trigger:
-- master
+- main
 - develop
 
 pool:
@@ -88,7 +88,7 @@ stages:
                 PathtoPublish: '$(ArtifactName)'
 
     - stage: Publish
-      condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/master'))
+      condition: and(succeeded(), eq(variables['build.sourceBranch'], 'refs/heads/main'))
       jobs: 
         - job: Publish
           steps:

--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -117,6 +117,7 @@ stages:
                 publishDirectory: '$(System.ArtifactsDirectory)/drop'
                 feedsToUsePublish: 'internal'
                 vstsFeedPackagePublish: 'kong-plugin-url-rewrite'
+                packagePublishDescription: 'kong-plugin-url-rewrite'
                 vstsFeedPublish: 'd8a23181-28c7-4e59-9cea-25e643da3675'
                 versionOption: 'custom'
                 versionPublish: $(ArtifactVersion)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: PublishPlugin
 
 on:
   push:
-    branches: [master]
+    branches: [master, legacy/v0]
 
   workflow_dispatch:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: PublishPlugin
 
 on:
   push:
-    branches: [master, legacy/v0]
+    branches: [main, legacy/v0]
 
   workflow_dispatch:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ You can run `luacov` and it will generate a `luacov.report.out` containing a com
 - **New Features** `feature/<Name of feature>` from `develop`.
 - **Bugfix** `bugfix/<Name of bugfix>` from `develop`.
 - **Improvements** `improvement/<Name of improvement>` from `develop`.
-- **Hotfix** `hotfix/<Name of hotfix>` from `master`.
+- **Hotfix** `hotfix/<Name of hotfix>` from `main`.
 
 ### Tests and coverage
 
@@ -97,7 +97,7 @@ git commit -m ":arrow_up: (APIDC-001) Updates rockspec"
 - **DO** ensure each commit successfully builds. The entire PR must pass all tests in the Continuous Integration (CI) system before it'll be merged.
 - **DO NOT** mix independent, unrelated changes in one PR. Separate real product/test code changes from larger code formatting/dead code removal changes. Separate unrelated fixes into separate PRs, especially if they are in different assemblies.
 - **DO** address PR feedback in an additional commit(s) rather than amending the existing commits, and only rebase/squash them when necessary. This makes it easier for reviewers to track changes. If necessary, squashing should be handled by the merger using the "squash and merge" feature, and should only be done by the contributor upon request.
-- **DO** all the PRs to `develop` branch unless it is a `hotfix`. For this one you should do for both `develop` and `master` branches.
+- **DO** all the PRs to `develop` branch unless it is a `hotfix`. For this one you should do for both `develop` and `main` branches.
 
 ### Guiding Principles
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,21 @@
 FROM debian:stretch
 
-RUN apt-get update
+RUN apt-get update -y
 
 RUN apt-get install -y \
-  lua5.2 \
-  liblua5.2-dev \
+  lua5.1 \
+  liblua5.1-0-dev \
   luarocks \
   git \
   libssl1.0-dev \
   make
 
+RUN git config --global url.https://github.com/.insteadOf git://github.com/
+
+WORKDIR /home/plugin
+
 ADD Makefile .
 RUN make setup
 
 ADD kong-plugin-url-rewrite-*.rockspec .
+RUN chmod -R a+rw /home/plugin

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ install:
 	-@luarocks remove $(LUA_PROJECT)
 	luarocks make
 
+docker-build:
+	docker build . -t $(LUA_PROJECT)
+
+docker-run:
+	docker run -it -v $(shell pwd):/home/plugin $(LUA_PROJECT) /bin/bash
+
 test:
 	cd $(PROJECT_FOLDER) && busted spec/ ${ARGS}
 

--- a/url-rewrite/handler.lua
+++ b/url-rewrite/handler.lua
@@ -40,6 +40,12 @@ function URLRewriter:access(config)
 
   local requestParams = getRequestUrlParams(config.url)
   local url = resolveUrlParams(requestParams, config.url)
+
+  local service_path = ngx.ctx.service.path or ""
+  if service_path ~= "" then
+    url = service_path..url
+  end
+
   ngx.var.upstream_uri = url
 end
 

--- a/url-rewrite/spec/handler_spec.lua
+++ b/url-rewrite/spec/handler_spec.lua
@@ -7,7 +7,8 @@ local ngx =  {
     ctx = {
       router_matches = {
         uri_captures = {}
-      }
+      },
+      service = {}
     },
     req = {
       get_uri_args = spy.new(function() return {} end),
@@ -28,6 +29,16 @@ describe("TestHandler", function()
     }
     URLRewriter:access(config)
     assert.equal('new_url', ngx.var.upstream_uri)
+  end)
+
+  it("should add service path to upstream_uri when it is present", function()
+    ngx.ctx.service['path'] = "path/to/"
+    config = {
+        url = "new_url"
+    }
+    URLRewriter:access(config)
+    assert.equal('path/to/new_url', ngx.var.upstream_uri)
+    ngx.ctx.service['path'] = nil
   end)
 
   it("should test rewrite of upstream_uri with params", function()


### PR DESCRIPTION
## Description
This PR adds kong service path to upstream route, when it's present.
It also changes default branch from `master` to `main`, when applicable.

## How Has This Been Tested?
By using the modified plugin inside kong and verifying that the service path is applied to upstream route.

