### PR TITLE
[main] Hotfix/v1.1.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
 
       - name: install
         run: |
+          git config --global url.https://github.com/.insteadOf git://github.com/
           sudo make setup
           sudo make install
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All changes made on any release of this project should be commented on high leve
 Document model based on [Semantic Versioning](http://semver.org/).
 Examples of how to use this _markdown_ cand be found here [Keep a CHANGELOG](http://keepachangelog.com/).
 
+### [1.1.1](https://github.com/stone-payments/kong-plugin-url-rewrite/compare/v1.1.0...v1.1.1) (2022-03-17)
+
+
+### Bug Fixes
+
+* Fixes luarocks package download during publish ([ae086cd](https://github.com/stone-payments/kong-plugin-url-rewrite/commit/ae086cd2015bc0b2037251f1be3953a808eb3d3f))
+
 ## [1.1.0](https://github.com/stone-payments/kong-plugin-url-rewrite/compare/v1.0.0...v1.1.0) (2022-03-16)
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DEV_ROCKS = "lua-cjson 2.1.0" "kong 2.6.0" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0"
 PROJECT_FOLDER = url-rewrite
 LUA_PROJECT = kong-plugin-url-rewrite
-VERSION = "1.1.0-0"
+VERSION = "1.1.1-0"
 
 setup:
 	cp rockspec.template kong-plugin-url-rewrite-$(VERSION).rockspec

--- a/rockspec.template
+++ b/rockspec.template
@@ -1,5 +1,5 @@
 package = "kong-plugin-url-rewrite"
-version = "1.1.0-0"
+version = "1.1.1-0"
 source = {
    url = "git://github.com/stone-payments/kong-plugin-url-rewrite",
 }


### PR DESCRIPTION
## Description
After #46 , we noticed that the plugin was not published to LuaRocks.
This was because some LuaRocks packages may use an insecure `git` protocol during download, which is not supported anymore.
The solution is to force git inside the workflow to run using `https` instead of `git`.

## How Has This Been Tested?
By publishing the package at the previous version using this modification. The package publishing was successful.
![Screenshot from 2022-03-17 19-46-36](https://user-images.githubusercontent.com/9416565/158911745-52ce73da-5176-4c6c-9cfa-dfd664ed8fb4.png)
![print](https://user-images.githubusercontent.com/9416565/158911754-6b0e7ad7-def2-4346-9e0c-3eef081de353.png)

