### PR TITLE
chore: Establishes a build standard between Dockerfile/CI/CD

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -5,7 +5,7 @@ trigger:
 - legacy/v0
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'ubuntu-latest'
 
 variables:
   plugin: 'url-rewrite'
@@ -16,18 +16,11 @@ stages:
         - job: Build
           steps:
           - bash: |
-              sudo apt install -y lua5.1
-              sudo apt install -y liblua5.1-dev
-
-              wget https://luarocks.org/releases/luarocks-3.3.1.tar.gz
-              tar zxpf luarocks-3.3.1.tar.gz
-              cd luarocks-3.3.1 && ./configure --with-lua-include=/usr/include/lua5.3 \
-                && make && sudo make install
-              cd .. && rm -rf luarocks-3.3.1 && rm luarocks-3.3.1.tar.gz
+              sudo apt update
+              sudo apt install -y lua5.1 liblua5.1-0-dev luarocks libssl-dev
             displayName: Install Lua and Luarocks
 
           - bash: |
-              sudo apt install -y libssl-dev
               wget https://download.konghq.com/gateway-0.x-ubuntu-xenial/pool/all/k/kong-community-edition/kong-community-edition_0.13.1_all.deb
               sudo apt install -y ./kong-community-edition_0.13.1_all.deb
               rm kong-community-edition_0.13.1_all.deb

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,10 @@ jobs:
 
       - name: before install
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev luarocks
-          sudo pip install hererocks
-          sudo hererocks lua_install -r^ --${{ env.LUA }}
-          export PATH=$PATH:$PWD/lua_install/bin
+          sudo apt update
+          sudo apt install -y lua5.1 liblua5.1-0-dev luarocks libssl-dev
+          wget https://download.konghq.com/gateway-0.x-ubuntu-xenial/pool/all/k/kong-community-edition/kong-community-edition_0.13.1_all.deb
+          sudo apt install -y ./kong-community-edition_0.13.1_all.deb
       - name: install
         run: |
           git config --global url.https://github.com/.insteadOf git://github.com/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-FROM debian:stretch
+FROM ubuntu:latest
 
-RUN apt-get update -y
+RUN apt update -y
 
-RUN apt-get install -y \
+RUN apt install -y \
   lua5.1 \
   liblua5.1-0-dev \
   luarocks \
   git \
-  libssl1.0-dev \
+  libssl-dev \
   make
+
+RUN wget https://download.konghq.com/gateway-0.x-ubuntu-xenial/pool/all/k/kong-community-edition/kong-community-edition_0.13.1_all.deb \
+  && apt install -y ./kong-community-edition_0.13.1_all.deb
 
 RUN git config --global url.https://github.com/.insteadOf git://github.com/
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DEV_ROCKS = "lua-cjson 2.1.0" "kong 0.13.0" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0"
+DEV_ROCKS = "lua-cjson 2.1.0" "kong 0.13.1" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0"
 PROJECT_FOLDER = url-rewrite
 LUA_PROJECT = kong-plugin-url-rewrite
 VERSION = 0.6.0-0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DEV_ROCKS = "lua-cjson 2.1.0" "kong 0.13.1" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0"
+DEV_ROCKS = "https://raw.githubusercontent.com/openresty/lua-cjson/2.1.0.8/lua-cjson-2.1.0.6-1.rockspec" "kong 0.13.1" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0"
 PROJECT_FOLDER = url-rewrite
 LUA_PROJECT = kong-plugin-url-rewrite
 VERSION = 0.6.0-0


### PR DESCRIPTION
## Description
After merging #50 , we discovered that there was a [compatibility issue](https://github.com/stone-payments/kong-plugin-url-rewrite/actions/runs/2227231259) involving ubuntu/luasec/libssl. This PR solves this problem, and also establishes a standard between Dockerfile/CI/CD pipeline, to try and catch this kind of problems sooner in the future.
## How Has This Been Tested?
By [mannualy running](https://github.com/stone-payments/kong-plugin-url-rewrite/runs/6178463084?check_suite_focus=true) the workflow to this branch, and confirming that it works as expected.
![Screenshot from 2022-04-26 11-19-49](https://user-images.githubusercontent.com/9416565/165335165-0d3300f9-07e5-4193-9e13-36d568e4e147.png)
