### PR TITLE
release/v0.6.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,4 +46,4 @@ jobs:
             LUAROCKS_API_KEY:${{ env.GCP_PROJECT_ID }}/LUAROCKS_APIKEY
       - name: deploy
         run: |
-          luarocks upload kong-plugin-url-rewrite-*.rockspec --api-key=${{ steps.luarocks-key.outputs.LUAROCKS_API_KEY }}
+          luarocks upload kong-plugin-url-rewrite-*.rockspec --force --api-key=${{ steps.luarocks-key.outputs.LUAROCKS_API_KEY }}

--- a/.standard-version/rockspec-updater.js
+++ b/.standard-version/rockspec-updater.js
@@ -1,12 +1,16 @@
-const capturingRegex = /version = "(?<version>[\d.]*)-0"/;
+const versionRegex = /version = "(?<version>[\d.]*)-0"/;
+const tagRegex = /tag = "v(?<version>[\d.]*)"/;
 
 module.exports.readVersion = function (contents) {
-  const { version } = contents.match(capturingRegex).groups;
+  const { version } = contents.match(versionRegex).groups;
   return version;
 };
 
 module.exports.writeVersion = function (contents, version) {
-  const replacer = () => `version = "${version}-0"`;
+  const versionReplacer = () => `version = "${version}-0"`;
+  const tagReplacer = () => `tag = "v${version}"`;
 
-  return contents.replace(capturingRegex, replacer);
+  return contents
+    .replace(versionRegex, versionReplacer)
+    .replace(tagRegex, tagReplacer);
 };

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -2,6 +2,10 @@
     "header": "# Changelog\n\nAll changes made on any release of this project should be commented on high level of this document.\n\nDocument model based on [Semantic Versioning](http://semver.org/).\nExamples of how to use this _markdown_ cand be found here [Keep a CHANGELOG](http://keepachangelog.com/).\n",
     "bumpFiles": [
         {
+            "filename": "package.json",
+            "type": "json"
+        },
+        {
             "filename": "rockspec.template",
             "updater": ".standard-version/rockspec-updater.js"
         },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All changes made on any release of this project should be commented on high leve
 Document model based on [Semantic Versioning](http://semver.org/).
 Examples of how to use this _markdown_ cand be found here [Keep a CHANGELOG](http://keepachangelog.com/).
 
+### [0.6.1](https://github.com/stone-payments/kong-plugin-url-rewrite/compare/v0.6.0...v0.6.1) (2022-05-04)
+
+
+### Bug Fixes
+
+* Fixes rockspec to consider tag/branch when uploading to LuaRocks ([43b59bd](https://github.com/stone-payments/kong-plugin-url-rewrite/commit/43b59bd43998c9aeaa4e7a2dc43cdf3537ec7948))
+
 ## [0.6.0](https://github.com/stone-payments/kong-plugin-url-rewrite/compare/v0.5.1...v0.6.0) (2022-04-25)
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DEV_ROCKS = "https://raw.githubusercontent.com/openresty/lua-cjson/2.1.0.8/lua-cjson-2.1.0.6-1.rockspec" "kong 0.13.1" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0"
 PROJECT_FOLDER = url-rewrite
 LUA_PROJECT = kong-plugin-url-rewrite
-VERSION = 0.6.0-0
+VERSION = 0.6.1-0
 
 setup:
 	cp rockspec.template kong-plugin-url-rewrite-$(VERSION).rockspec

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "dependencies": {
         "standard-version": "^9.3.2"
     },
-    "version": "0.6.0",
+    "version": "0.6.1",
     "scripts": {
         "release": "standard-version"
     }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+    "dependencies": {
+        "standard-version": "^9.3.2"
+    },
+    "version": "0.6.0",
+    "scripts": {
+        "release": "standard-version"
+    }
+}

--- a/rockspec.template
+++ b/rockspec.template
@@ -1,9 +1,9 @@
 package = "kong-plugin-url-rewrite"
-version = "0.6.0-0"
+version = "0.6.1-0"
 source = {
    url = "git://github.com/stone-payments/kong-plugin-url-rewrite",
    branch = "legacy/v0",
-   tag = "v0.6.0",
+   tag = "v0.6.1",
 }
 description = {
   summary = "KongAPI Gateway middleware plugin for url-rewrite purposes.",

--- a/rockspec.template
+++ b/rockspec.template
@@ -2,6 +2,8 @@ package = "kong-plugin-url-rewrite"
 version = "0.6.0-0"
 source = {
    url = "git://github.com/stone-payments/kong-plugin-url-rewrite",
+   branch = "legacy/v0",
+   tag = "v0.6.0",
 }
 description = {
   summary = "KongAPI Gateway middleware plugin for url-rewrite purposes.",


### PR DESCRIPTION
## Description
After #49 , we discovered that even with the plugin upload process running on the `legacy/v0` branch, we're ending up with a LuaRocks package that was based on the `main` branch, therefore incompatible with kong `0.13.x`.

This is because the LuaRocks upload process [needs a tag or branch](https://github.com/luarocks/luarocks/wiki/Creating-a-rock#method-1-using-a-repository-such-as-github) specified in the `.rockspec` file, otherwise it will always use the default branch as the base for the package.

This PR fixes the problem, by specifying the correct branch and tag in the `.rockspec` file.

## How Has This Been Tested?
By uploading the new version to LuaRocks, and confirming that the package correctly integrates with kong < `1.x`.