### PR TITLE
feat: Ensures compatibility with kong v3.0

### DIFF
--- a/.azure-pipelines/pipeline.yml
+++ b/.azure-pipelines/pipeline.yml
@@ -7,7 +7,7 @@ trigger:
 - develop
 
 pool:
-  vmImage: 'ubuntu-18.04'
+  vmImage: 'ubuntu-latest'
 
 variables:
   plugin: 'url-rewrite'
@@ -18,21 +18,21 @@ stages:
         - job: Build
           steps:
           - bash: |
-              sudo apt install -y lua5.3
-              sudo apt install -y liblua5.3-dev
+              sudo apt install -y lua5.1
+              sudo apt install -y liblua5.1-dev
 
               wget https://luarocks.org/releases/luarocks-3.3.1.tar.gz
               tar zxpf luarocks-3.3.1.tar.gz
-              cd luarocks-3.3.1 && ./configure --with-lua-include=/usr/include/lua5.3 \
+              cd luarocks-3.3.1 && ./configure --with-lua-include=/usr/include/lua5.1 \
                 && make && sudo make install
               cd .. && rm -rf luarocks-3.3.1 && rm luarocks-3.3.1.tar.gz
             displayName: Install Lua and Luarocks
 
           - bash: |
               sudo apt install -y libssl-dev
-              wget https://download.konghq.com/gateway-2.x-ubuntu-bionic/pool/all/k/kong/kong_2.6.0_amd64.deb
-              sudo apt install -y ./kong_2.6.0_amd64.deb
-              rm kong_2.6.0_amd64.deb
+              wget https://download.konghq.com/gateway-3.x-ubuntu-bionic/pool/all/k/kong/kong_3.0.0_amd64.deb
+              sudo apt install -y ./kong_3.0.0_amd64.deb
+              rm kong_3.0.0_amd64.deb
             displayName: Install kong
 
           - task: Bash@3

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @andremacdowell @brennogb @glauberatanaka @guih50 @henrique1996n1 @jonathanlazaro1 @leoferlopes @mauriciokb @Wuerike

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,20 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      - name: 'Create PR: Merge main into develop branch'
+        id: create-develop-pull-request
+        uses: thomaseizinger/create-pull-request@1.2.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: main
+          base: develop
+          labels: develop
+          title: Merge main into develop branch
+          body: |
+            This PR merges the main branch back into develop.
+            This happens to ensure that the updates that happend on the release branch, i.e. CHANGELOG and manifest updates are also present on the develop branch.
+
       - name: before install
         run: |
           sudo apt-get update

--- a/.standard-version/package-updater.js
+++ b/.standard-version/package-updater.js
@@ -1,0 +1,12 @@
+const capturingRegex = /VERSION = "(?<version>[\d.]*)"/;
+
+module.exports.readVersion = function (contents) {
+  const { version } = contents.match(capturingRegex).groups;
+  return version;
+};
+
+module.exports.writeVersion = function (contents, version) {
+  const replacer = () => `VERSION = "${version}"`;
+
+  return contents.replace(capturingRegex, replacer);
+};

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -8,6 +8,10 @@
         {
             "filename": "Makefile",
             "updater": ".standard-version/makefile-updater.js"
+        },
+        {
+            "filename": "url-rewrite/handler.lua",
+            "updater": ".standard-version/package-updater.js"
         }
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,16 @@
-FROM debian:stretch
+FROM ubuntu:22.04
 
 RUN apt-get update -y
 
-RUN apt-get install -y \
-  lua5.1 \
-  liblua5.1-0-dev \
-  luarocks \
-  git \
-  libssl1.0-dev \
-  make
-
+RUN apt update -y && apt install -y lua5.1 liblua5.1-dev build-essential wget git zip unzip
 RUN git config --global url.https://github.com/.insteadOf git://github.com/
+RUN wget https://download.konghq.com/gateway-3.x-ubuntu-bionic/pool/all/k/kong/kong_3.0.0_amd64.deb &&\
+  apt install -y ./kong_3.0.0_amd64.deb
 
 WORKDIR /home/plugin
 
-ADD Makefile .
+COPY Makefile .
+COPY rockspec.template .
 RUN make setup
 
-ADD kong-plugin-url-rewrite-*.rockspec .
 RUN chmod -R a+rw /home/plugin

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DEV_ROCKS = "lua-cjson 2.1.0" "kong 2.6.0" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0"
+DEV_ROCKS = "lua-cjson 2.1.0" "kong 3.0.0" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0"
 PROJECT_FOLDER = url-rewrite
 LUA_PROJECT = kong-plugin-url-rewrite
 VERSION = "1.1.1-0"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DEV_ROCKS = "lua-cjson 2.1.0" "kong 3.0.0" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0"
+DEV_ROCKS = "https://raw.githubusercontent.com/openresty/lua-cjson/2.1.0.8/lua-cjson-2.1.0.6-1.rockspec" "kong 3.0.0" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0"
 PROJECT_FOLDER = url-rewrite
 LUA_PROJECT = kong-plugin-url-rewrite
 VERSION = "1.1.1-0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+
+  kong:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    stdin_open: true
+    volumes: 
+      - ./${PROJECT_FOLDER}:/home/plugin
+    ports:
+      - "8001:8001"
+      - "8000:8000"
+    entrypoint: /bin/bash

--- a/rockspec.template
+++ b/rockspec.template
@@ -2,6 +2,8 @@ package = "kong-plugin-url-rewrite"
 version = "1.1.1-0"
 source = {
    url = "git://github.com/stone-payments/kong-plugin-url-rewrite",
+   branch = "main",
+   tag = "v1.1.1",
 }
 description = {
   summary = "KongAPI Gateway middleware plugin for url-rewrite purposes.",

--- a/url-rewrite/handler.lua
+++ b/url-rewrite/handler.lua
@@ -1,5 +1,6 @@
 local URLRewriter = {
-  PRIORITY = 700
+  PRIORITY = 700,
+  VERSION = "1.1.1"
 }
 
 function split(s, delimiter)


### PR DESCRIPTION
## Description
This PR ensures compatibility with kong v3.0, by bringing the only necessary change: to add the (now [mandatory](https://github.com/Kong/kong/pull/8836)) `VERSION` info to `handler.lua`.

## How Has This Been Tested?
- By using the plugin with kong 3.0
- By running the repo tests
