### PR TITLE
feat: Build and upload .rock artifact on release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+spec
+.pongo
+kong-pongo
+servroot
+*.rock
+docs

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,23 @@ jobs:
       - name: Checkout repo at main
         uses: actions/checkout@v4
 
+      - name: Build and upload .rock
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_BUILDKIT: '1'
+          KONG_IMAGE: kong/kong-gateway:3.14-amazonlinux-2023
+        run: |
+          docker build \
+            --target export \
+            --build-arg KONG_IMAGE="$KONG_IMAGE" \
+            --output ./out .
+          KONG_VERSION=$(echo "$KONG_IMAGE" | sed -E 's|.*:([0-9]+\.[0-9]+).*|\1|')
+          for rock in ./out/*.rock; do
+            mv "$rock" "${rock%.rock}.kong-${KONG_VERSION}.rock"
+          done
+          gh release upload "${{ steps.release.outputs.tag_name }}" ./out/*.rock --repo "$GITHUB_REPOSITORY" --clobber
+
       - name: Check if remote release branch exists
         id: branch_check
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,28 @@
-FROM kong/kong-gateway:3.7.1.2-amazonlinux-2023 AS lua_builder
+ARG KONG_IMAGE=kong/kong-gateway:3.14-amazonlinux-2023
 
+# Stage 1: builder — gera o .rock
+FROM ${KONG_IMAGE} AS builder
 USER root
-WORKDIR /
+WORKDIR /work
 
-RUN yum -y install tar-2:1.34-1.amzn2023.0.4 git-2.40.1-1.amzn2023.0.3 openssl-devel-1:3.0.8-1.amzn2023.0.12 make-1:4.3-5.amzn2023.0.2 && yum -y clean all
+RUN yum -y install tar-2:1.34-1.amzn2023.0.4 git-2.50.1-1.amzn2023.0.1 openssl-devel-1:3.5.5-1.amzn2023.0.3 make-1:4.3-5.amzn2023.0.2 && yum -y clean all
 
-COPY . /
+COPY . .
 RUN make rockspec \
-  && luarocks make --pack-binary-rock --only-server https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/daab2726276e3282dc347b89a42a5107c3500567 \
-  && mkdir -p /build/plugin \
-  && find . -name *.rock -exec cp {} /build/plugin \;
+    && luarocks make --pack-binary-rock --deps-mode=none
 
-FROM kong/kong-gateway:3.7.1.2-amazonlinux-2023
+# Stage 2: export — apenas o .rock
+FROM scratch AS export
+COPY --from=builder /work/*.rock /
 
+# Stage 3: runtime — preserva o uso atual do Dockerfile
+FROM ${KONG_IMAGE} AS runtime
 USER root
 
-RUN yum -y install git-2.40.1-1.amzn2023.0.3 && yum -y clean all
+RUN yum -y install git-2.50.1-1.amzn2023.0.1 unzip-6.0-68.amzn2023.0.1 && yum -y clean all
 
-WORKDIR /
-COPY --from=lua_builder  /build/plugin/* /
-RUN find . -name *.rock -exec luarocks install ./{} --only-server https://raw.githubusercontent.com/rocks-moonscript-org/moonrocks-mirror/daab2726276e3282dc347b89a42a5107c3500567 \;
+WORKDIR /work
+COPY --from=builder /work/*.rock /tmp/
+RUN luarocks install /tmp/*.rock
 
 USER kong


### PR DESCRIPTION
## Descrição

Parte do rollout do épico **PCAG-2565** (artifact-based plugin build): publica o `.rock` pré-empacotado como asset do GitHub Release.

**Mudanças:**
- **`Dockerfile`** — multi-stage (`builder`/`export`/`runtime`); `ARG KONG_IMAGE` default `kong/kong-gateway:3.14-amazonlinux-2023`; `export` (`FROM scratch`) expõe o `.rock`; `runtime` preserva o uso atual. Removido LuaRocks from-source; adicionado `unzip`.
- **`.github/workflows/release-please.yml`** — novo step `Build and upload .rock` (condicional a `release_created == 'true'`).
- **`.dockerignore`** — reduz o contexto de build.

## Como estas mudanças foram testadas?

- Padrão idêntico ao do piloto (#6). O upload roda só em `release_created == 'true'`, então este PR **não** dispara o build/upload. Dockerfile/YAML validados por inspeção + lint.

## Links

- Épico: https://allstone.atlassian.net/browse/PCAG-2565
