### PR TITLE
fix: Install JSON library for LuaRocks upload

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y luarocks
+          sudo luarocks install dkjson
           luarocks upload kong-plugin-url-rewrite-*.rockspec --api-key=${{ secrets.LUAROCKS_API_KEY }}
 
       - name: Check if remote release branch exists


### PR DESCRIPTION
## Description

O step `Publish to LuaRocks` falhou no release com:

```
Error: A JSON library is required for this command. Failed loading 'cjson', 'dkjson', and 'json'.
```

**Causa raiz:** o `luarocks upload` usa a API HTTP do luarocks.org e precisa de uma biblioteca JSON para serializar a requisição. O pacote `luarocks` do apt não traz nenhuma. Quando o step foi enxugado para apenas `luarocks upload`, a dependência JSON (que antes vinha de carona no `make setup` via `lua-cjson`) deixou de ser instalada.

**Correção:** instalar `dkjson` (Lua puro, sem etapa de compilação) antes do upload:

```yaml
sudo luarocks install dkjson
```

> Observação: o `luasec` (necessário para o HTTPS) já é instalado automaticamente como dependência do pacote `luarocks` do apt.

Mesma correção aplicada no kong-plugin-template-transformer (#189).

## How Has This Been Tested?

- Validação de sintaxe YAML do `release-please.yml`.
- Erro idêntico já reproduzido no plugin irmão; `dkjson` resolve exatamente a dependência reportada (`cjson/dkjson/json`).
- Mudança restrita ao workflow de CI (sem alteração no código Lua do plugin).