### PR TITLE
feat!: validates config.url as a required RFC 3986 path

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@commitlint/config-conventional"]
+}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -11,9 +11,9 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v1
-        with: 
+      - uses: wagoid/commitlint-github-action@v6
+        with:
           configFile: .commitlintrc.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,11 +31,11 @@ commit message**, so the PR title is what drives the version bump. Get it right:
 
 | PR title prefix              | Version bump | Example                                         |
 | ---------------------------- | ------------ | ----------------------------------------------- |
-| `fix: ...`                   | patch        | `fix: prepend service path only when present`   |
-| `feat: ...`                  | minor        | `feat: validate config.url as an RFC 3986 path` |
-| `feat!: ...` / `fix!: ...`   | major        | `feat!: require config.url to start with a /`   |
-| `BREAKING CHANGE:` in body   | major        | breaking change footer in the squash body       |
-| `chore:`, `docs:`, `test:` … | no release   | `docs: document placeholder syntax`             |
+| `fix: ...`                   | patch        | `fix: prepends service path only when present`   |
+| `feat: ...`                  | minor        | `feat: validates config.url as an RFC 3986 path` |
+| `feat!: ...` / `fix!: ...`   | major        | `feat!: requires config.url to start with a /`   |
+| `BREAKING CHANGE:` in body   | major        | breaking change footer in the squash body        |
+| `chore:`, `docs:`, `test:` … | no release   | `docs: documents placeholder syntax`             |
 
 When a change is backwards-incompatible (e.g. a config field becomes stricter),
 mark it as breaking (`!` or a `BREAKING CHANGE:` footer) so release-please bumps
@@ -58,18 +58,20 @@ message).
 
 - **type** — one of: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
   `build`, `ci`, `chore`, `revert`.
-- **description** — short, imperative mood, lower-case, no trailing period
-  (e.g. "add", not "added"/"adds").
+- **description** — start with a **present-tense, third-person-singular verb** so
+  the subject reads as the answer to "what does this do?" (e.g. "adds", "fixes",
+  "validates" — not "add"/"added"). Keep it lower-case with no trailing period;
+  the squashed PR title is what lands in the changelog.
 - **breaking change** — append `!` after the type/scope **or** add a
   `BREAKING CHANGE: <explanation>` footer.
 
 Examples:
 
 ```
-feat: validate config.url as an RFC 3986 path
-fix(handler): prepend service path only when present
-docs: document the query_string configuration field
-feat!: require config.url to start with a forward slash
+feat: validates config.url as an RFC 3986 path
+fix(handler): prepends the service path only when present
+docs: documents the query_string configuration field
+feat!: requires config.url to start with a forward slash
 ```
 
 ## Testing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,94 @@
+# Repository Guidelines
+
+Conventions for anyone — humans or AI agents — contributing to this repository.
+For the broader contribution workflow, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Language
+
+This is a **public repository**. All commits, code comments, PR titles, and PR
+descriptions MUST be written in **English**.
+
+## Public repository — do not leak internal information
+
+Because the repository is public, never expose anything internal in commits,
+code comments, or PR titles/descriptions, including (but not limited to):
+
+- Jira task keys or links
+- Internal initiatives, roadmaps, or project codenames
+- Internal URLs, hostnames, dashboards, or service names
+- Employee names tied to internal context, or any other confidential data
+
+Describe changes purely in terms of the public plugin's behavior.
+
+## Releases & commit messages
+
+Releases are automated by [release-please](https://github.com/googleapis/release-please),
+which derives the next version and the changelog from
+[Conventional Commits](https://www.conventionalcommits.org/).
+
+**Only squash merges are allowed.** On a squash merge the **PR title becomes the
+commit message**, so the PR title is what drives the version bump. Get it right:
+
+| PR title prefix              | Version bump | Example                                         |
+| ---------------------------- | ------------ | ----------------------------------------------- |
+| `fix: ...`                   | patch        | `fix: prepend service path only when present`   |
+| `feat: ...`                  | minor        | `feat: validate config.url as an RFC 3986 path` |
+| `feat!: ...` / `fix!: ...`   | major        | `feat!: require config.url to start with a /`   |
+| `BREAKING CHANGE:` in body   | major        | breaking change footer in the squash body       |
+| `chore:`, `docs:`, `test:` … | no release   | `docs: document placeholder syntax`             |
+
+When a change is backwards-incompatible (e.g. a config field becomes stricter),
+mark it as breaking (`!` or a `BREAKING CHANGE:` footer) so release-please bumps
+the major version.
+
+### Commit message format
+
+Commit messages MUST follow [Conventional Commits](https://www.conventionalcommits.org/).
+This is enforced in CI by [commitlint](https://commitlint.js.org/) on every commit
+of a pull request, and the same rules apply to the PR title (the squash commit
+message).
+
+```
+<type>[optional scope][!]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+- **type** — one of: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
+  `build`, `ci`, `chore`, `revert`.
+- **description** — short, imperative mood, lower-case, no trailing period
+  (e.g. "add", not "added"/"adds").
+- **breaking change** — append `!` after the type/scope **or** add a
+  `BREAKING CHANGE: <explanation>` footer.
+
+Examples:
+
+```
+feat: validate config.url as an RFC 3986 path
+fix(handler): prepend service path only when present
+docs: document the query_string configuration field
+feat!: require config.url to start with a forward slash
+```
+
+## Testing
+
+Tests run with [Kong Pongo](https://github.com/Kong/kong-pongo):
+
+```bash
+make test          # pongo run -- -t unit
+pongo run          # full suite, as in CI
+```
+
+### Test file naming convention
+
+Every test file lives in `spec/` and ends with `_spec.lua`. The numeric prefix
+marks its category:
+
+- `01-unit_*_spec.lua` — unit tests (isolated functions/modules)
+- `02-integration_*_spec.lua` — integration tests
+- `03-functional_*_spec.lua` — functional / end-to-end tests
+
+Add new tests when introducing features, and start bug fixes with a test that
+reproduces the broken behavior.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,76 +1,119 @@
 # Contributor Guidelines
 
-:honeybee: Please read this document before beginning any implementation, we use a set of guidelines that should be followed.:honeybee:
+:honeybee: Please read this document before beginning any implementation. We use a
+set of guidelines that should be followed. :honeybee:
+
+Repository-wide conventions (language, public-repo rules, release automation,
+test naming) live in [AGENTS.md](AGENTS.md) — read it first; this document
+focuses on the contribution workflow.
 
 ## DOs and DON'Ts
 
-- **DO** follow our git branching styleguide
-- **DO** give priority to the current style of the project or file you're changing even if it diverges from the general guidelines
-- **DO** include tests when adding new features. When fixing bugs, start with adding a test that highlights how the current behavior is broken
-- **DO** keep the discussions focused. When a new or related topic comes up it's often better to create a new issue than to side track the discussion
-- **DO NOT** make PRs for style changes
-- **DO NOT** surprise us with big pull requests. Instead, file an issue and start a discussion so we can agree on a direction before you invest a large amount of time working on it
-- **DO NOT** add API additions without filing an issue and discussing with us first
+- **DO** give priority to the current style of the project or file you're changing
+  even if it diverges from the general guidelines
+- **DO** include tests when adding new features. When fixing bugs, start with a
+  test that highlights how the current behavior is broken
+- **DO** keep discussions focused. When a new or related topic comes up it's often
+  better to open a new issue than to side-track the discussion
+- **DO NOT** make PRs for style-only changes
+- **DO NOT** surprise us with big pull requests. Instead, open an issue and start a
+  discussion so we can agree on a direction before you invest a large amount of time
+- **DO NOT** add public API/configuration changes without opening an issue and
+  discussing with us first
 
-## Testing
+## Workflow
 
-We're using [busted](http://olivinelabs.com/busted) to run our tests. Every test file should live in a `spec` folder and end with `_spec.lua`.
+We follow a **trunk-based / GitHub Flow** model:
 
-### Running the tests
+1. Branch off `main` (the default branch) into a short-lived branch.
+2. Open a pull request back into `main` when the work is ready for review.
+3. The PR is merged via **squash merge** after review and a green CI run.
 
-`make test` or `busted spec/` in the plugin folder should do the job.
-
-remember to run it as super user if your current environment needs it.
-
-### Test Coverage
-
-If you're using our Makefile, just run `make coverage`.
-
-With Busted, a `-c` flag will do the job.
-It will generate a `luacov.stats.out` that you can use to generate coverage reports.
-You can run `luacov` and it will generate a `luacov.report.out` containing a comprehensive coverage report.
-
-## Lint
-
-`make lint` or `luacheck -q .` in the plugin folder should run the linter.
-
-### Adding External Library Dependencies
-
-- Add new dependencies to the project ONLY IF STRICTLY NECESSARY, we know that adding new dependencies is easier, but by doing so it increases the build time of the framework.
-
-### Workflow
-
-- We use GitFlow, you can find more about this workfow [here](http://nvie.com/posts/a-successful-git-branching-model/).
+There are no long-lived `develop`, `release`, or `hotfix` branches.
 
 ### Branching
 
-- **New Features** `feature/<Name of feature>` from `main`.
-- **Bugfix** `bugfix/<Name of bugfix>` from `main`.
-- **Improvements** `improvement/<Name of improvement>` from `main`.
-- **Hotfix** `hotfix/<Name of hotfix>` from `main`.
+Use a short, descriptive branch name prefixed with the change type, e.g.:
 
-### Tests and coverage
+- `feat/<short-description>`
+- `fix/<short-description>`
+- `chore/<short-description>`
+- `docs/<short-description>`
 
-- Don't forget to write tests!!
-- We'd like to keep our project with a minimum of 60%, but 90% is the desirable target.
+## Commits & Pull Requests
 
-### Commit messages
+Versioning and the changelog are automated by
+[release-please](https://github.com/googleapis/release-please) from
+[Conventional Commits](https://www.conventionalcommits.org/). Commit messages are
+validated in CI by [commitlint](https://commitlint.js.org/), and the same format
+applies to the PR title. See
+[AGENTS.md](AGENTS.md#commit-message-format) for the exact format and the
+version-bump rules.
 
-See [release-please](https://github.com/googleapis/release-please?tab=readme-ov-file#how-should-i-write-my-commits) for commit guidelines.
+Because **only squash merges are allowed, the PR title becomes the commit message
+that drives the release**, so it MUST follow Conventional Commits:
 
-### Pull Requests
+- ✅ `feat: validate config.url as an RFC 3986 path`
+- ✅ `fix: prepend service path only when present`
+- ❌ `Fix #1234` / `Improves coverage by 10%`
 
-- **DO** give PRs short-but-descriptive names (e.g. "Improves code coverage for System.Console by 10%", not "Fix #1234").
-- **DO NOT** submit "work in progress" PRs. A PR should only be submitted when it is considered ready for review and subsequent merging by the contributor.
+Additional guidelines:
+
+- **DO NOT** submit "work in progress" PRs. Open a PR only when it is ready for
+  review and subsequent merging.
 - **DO** tag any users that should know about and/or review the change.
-- **DO** submit all code changes via pull requests (PRs) rather than through a direct commit. PRs will be reviewed and potentially merged by the repo maintainers after a peer review that includes at least one maintainer.
-- **DO** ensure each commit successfully builds. The entire PR must pass all tests in the Continuous Integration (CI) system before it'll be merged.
-- **DO NOT** mix independent, unrelated changes in one PR. Separate real product/test code changes from larger code formatting/dead code removal changes. Separate unrelated fixes into separate PRs, especially if they are in different assemblies.
-- **DO** address PR feedback in an additional commit(s) rather than amending the existing commits, and only rebase/squash them when necessary. This makes it easier for reviewers to track changes. If necessary, squashing should be handled by the merger using the "squash and merge" feature, and should only be done by the contributor upon request.
+- **DO** submit all code changes via pull requests rather than direct commits. PRs
+  are reviewed and merged by maintainers after a peer review including at least one
+  maintainer.
+- **DO** ensure CI is green. The entire PR must pass all tests before it is merged.
+- **DO NOT** mix independent, unrelated changes in one PR. Separate unrelated fixes
+  into separate PRs.
+- **DO** address PR feedback in additional commits rather than amending existing
+  ones — it makes review easier. Everything is squashed on merge anyway.
 
-### Guiding Principles
+## Testing
 
-- We allow anyone to participate in our projects. Tasks can be carried out by anyone that demonstrates the capability to complete them.
-- Always be respectful of one another. Assume the best in others and act with empathy at all times.
-- Collaborate closely with individuals maintaining the project or experienced users. Getting ideas out in the open and seeing a proposal before it's a pull request helps reduce redundancy and ensures we're all connected to the decision making process.
+We use [Kong Pongo](https://github.com/Kong/kong-pongo) to run our tests. Every
+test file lives in the `spec/` folder, ends with `_spec.lua`, and follows the
+naming convention described in [AGENTS.md](AGENTS.md#test-file-naming-convention)
+(`01-unit_*`, `02-integration_*`, `03-functional_*`).
+
+### Running the tests
+
+```bash
+make test     # pongo run -- -t unit
+pongo run     # full suite, as in CI
+```
+
+### Test coverage
+
+```bash
+pongo run -- --coverage
+```
+
+We'd like to keep coverage at a minimum of 60%, with 90% as the desirable target.
+
+## Lint
+
+Linting is done with [luacheck](https://github.com/lunarmodules/luacheck), run
+through Pongo:
+
+```bash
+make lint     # pongo lint
+```
+
+## Adding External Library Dependencies
+
+- Add new dependencies ONLY IF STRICTLY NECESSARY. Adding dependencies is easy, but
+  it increases the build time and the maintenance surface of the plugin.
+
+## Guiding Principles
+
+- We allow anyone to participate in our projects. Tasks can be carried out by anyone
+  who demonstrates the capability to complete them.
+- Always be respectful of one another. Assume the best in others and act with empathy
+  at all times.
+- Collaborate closely with the people maintaining the project. Getting ideas out in
+  the open before a pull request reduces redundancy and keeps everyone connected to
+  the decision-making process.
 - Don't be a jerk.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 KONG_VERSION = 3.7.1.2
 DEV_ROCKS = "https://raw.githubusercontent.com/openresty/lua-cjson/2.1.0.8/lua-cjson-2.1.0.6-1.rockspec" "kong $(KONG_VERSION)" "luacov 0.12.0" "busted 2.0.rc12" "luacov-cobertura 0.2-1" "luacheck 0.20.0"
-PROJECT_FOLDER = url-rewrite
 LUA_PROJECT = kong-plugin-url-rewrite
 VERSION = $(shell cat version.txt)
 
@@ -45,10 +44,10 @@ test:
 	KONG_VERSION=$(KONG_VERSION) pongo run -- -t unit
 
 coverage:
-	cd $(PROJECT_FOLDER) && busted spec/ -c && luacov && luacov-cobertura -o cobertura.xml
+	KONG_VERSION=$(KONG_VERSION) pongo run -- --coverage
 
 package:
 	luarocks make --pack-binary-rock
 
 lint:
-	cd $(PROJECT_FOLDER) && luacheck -q .
+	KONG_VERSION=$(KONG_VERSION) pongo lint

--- a/README.md
+++ b/README.md
@@ -1,43 +1,73 @@
-[![Build Status](https://travis-ci.org/stone-payments/kong-plugin-url-rewrite.svg?branch=master)](https://travis-ci.org/stone-payments/kong-plugin-url-rewrite)
+# kong-plugin-url-rewrite
 
-# Kong-plugin-url-rewrite
-
-Kong API Gateway plugin for url-rewrite purposes. This plugin has been tested to work along with kong >= 2.6.x, for a legacy version of this plugin, please check [this link](https://github.com/stone-payments/kong-plugin-url-rewrite/tree/legacy/v0).
+Kong API Gateway plugin for url-rewrite purposes. This plugin has been tested to work along with kong >= 3.x, for a legacy version of this plugin, please check [this link](https://github.com/stone-payments/kong-plugin-url-rewrite/tree/legacy/v0).
 
 ## The Problem
 
-When using Kong, you can create routes that proxy to an upstream. The problem lies when the upstream has an url that is not very friendly to your clients, or restful, or even pretty. When you [add a Route in Kong](https://docs.konghq.com/0.14.x/admin-api/#add-route), you have a [somewhat limited](https://docs.konghq.com/0.14.x/proxy/#routes-and-matching-capabilities) url rewrite capability. This plugin simply throws away the url set in Kong route and uses the url set in it's configuration to proxy to the upstream. This gives you full freedom as to how to write your url's in Kong and inner services as well.
-
-## Project Structure
-
-The plugin folder should contain at least a `schema.lua` and a `handler.lua`, alongside with a `spec` folder and a `.rockspec` file specifying the current version of the package.
-
-## Rockspec Format
-
-The `.rockspec` file should follow [LuaRocks' conventions](https://github.com/luarocks/luarocks/wiki/Rockspec-format)
+When using Kong, you can create routes that proxy to an upstream. The problem lies when the upstream has a URL that is not very friendly to your clients, or RESTful, or even pretty. When you [add a Route in Kong](https://docs.konghq.com/gateway/latest/admin-api/#route-object), you have a [somewhat limited](https://docs.konghq.com/gateway/latest/key-concepts/routes/) URL rewrite capability. This plugin simply throws away the URL set in the Kong route and uses the URL set in its configuration to proxy to the upstream. This gives you full freedom over how to write your URLs in Kong and inner services as well.
 
 ## Configuration
 
+| Parameter            | Required | Description                                                                                                                                                                                                 |
+| -------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `config.url`         | yes      | The path used to rewrite the upstream URI. It **must start with a forward slash (`/`)** and may only contain characters from the RFC 3986 reserved list. Supports `<capture_name>` placeholders (see below). |
+| `config.query_string` | no       | An array of `key=value` strings appended to the upstream query string. Values also support `<capture_name>` placeholders.                                                                                    |
+
+### Placeholders
+
+A `<capture_name>` placeholder is replaced at request time with the value of the
+matching **named RegEx capture** from the route's path. For example, a route with
+the path `~/foo/(?<bar>\S+)` exposes a `bar` capture that you can reference as
+`<bar>` in `config.url` or `config.query_string`.
+
+If the matched Kong service has a `path`, it is prepended to the rewritten URL.
+
 ### Enabling the plugin on a Route
 
-Configure this plugin on a Route with:
+With the Admin API:
 
 ```bash
 curl -X POST http://kong:8001/routes/{route_id}/plugins \
-    --data "name=kong-plugin-url-rewrite"  \
-    --data "config.url=http://new-url.com"
+    --data "name=url-rewrite" \
+    --data "config.url=/new/path/<capture>"
 ```
 
-- route_id: the id of the Route that this plugin configuration will target.
-- config.url: the url where you want kong to execute the request.
+- `route_id`: the id of the Route that this plugin configuration will target.
+
+Declaratively (DB-less), as in [kong.yaml](kong.yaml):
+
+```yaml
+routes:
+  - name: echo-route
+    paths:
+      - ~/foo/(?<bar>\S+)
+    strip_path: false
+    plugins:
+      - name: url-rewrite
+        config:
+          url: /baz/<bar>
+          query_string:
+            - origin=foo
+            - id=<bar>
+```
+
+A request to `/foo/123` is proxied upstream as `/baz/123?origin=foo&id=123`.
 
 ## Developing
 
-### In docker
+A DB-less Kong (plus an echo upstream) is provided via Docker Compose for local
+testing:
 
 ```bash
-docker build . -t kong-plugin-url-rewrite-dev
-docker run -it -v ${PWD}/url-rewrite:/url-rewrite kong-plugin-url-rewrite-dev bash
+docker compose up --build
+# then send requests through http://localhost:8000
+```
+
+Tests run with [Kong Pongo](https://github.com/Kong/kong-pongo) — see
+[CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
+
+```bash
+make test
 ```
 
 ## Credits

--- a/kong/plugins/url-rewrite/schema.lua
+++ b/kong/plugins/url-rewrite/schema.lua
@@ -1,5 +1,36 @@
 local typedefs = require 'kong.db.schema.typedefs'
 
+-- Mirrors Kong's `validate_path` (kong/db/schema/typedefs.lua) so the rewritten
+-- URL is checked against the RFC 3986 reserved character list and is required
+-- to start with a forward slash. The only accommodation for this plugin's
+-- templating semantics is that `<param>` placeholders are replaced with a dummy
+-- segment before validation, since the captured RegEx values are only known at
+-- runtime.
+local function validate_rewrite_path(path)
+  -- replace `<param>` placeholders with a dummy value so the resulting
+  -- string can be validated as a real path
+  local resolved = path:gsub("<[^>]*>", "foo")
+
+  if not resolved:match("^/[%w%.%-%_%~%/%%%:%@" ..
+                        "%!%$%&%'%(%)%*%+%,%;%=" .. -- RFC 3986 "sub-delims"
+                        "]*$")
+  then
+    return nil,
+           "invalid path: '" .. path ..
+           "' (must start with '/' and only contain characters from the " ..
+           "reserved list of RFC 3986)"
+  end
+
+  -- ensure it is properly percent-encoded
+  local raw = resolved:gsub("%%%x%x", "___")
+  if raw:find("%", nil, true) then
+    local err = raw:sub(raw:find("%%.?.?"))
+    return nil, "invalid url-encoded value: '" .. err .. "'"
+  end
+
+  return true
+end
+
 return {
   name = "url-rewrite",
   fields = {
@@ -8,7 +39,7 @@ return {
       config = {
         type = "record",
         fields = {
-          { url = { required = true, type = "string" }, },
+          { url = { required = true, type = "string", custom_validator = validate_rewrite_path }, },
           { query_string = { required = false, type = "array", elements = { type = "string" } } },
         }
       }

--- a/spec/01-unit_schema_spec.lua
+++ b/spec/01-unit_schema_spec.lua
@@ -1,0 +1,104 @@
+local PLUGIN_NAME = "url-rewrite"
+
+-- helper that validates a `config` table against the plugin schema
+local validate do
+  local validate_entity = require("spec.helpers").validate_plugin_config_schema
+  local plugin_schema = require("kong.plugins." .. PLUGIN_NAME .. ".schema")
+
+  function validate(config)
+    return validate_entity(config, plugin_schema)
+  end
+end
+
+describe("Test #unit schema", function()
+
+  describe("config.url", function()
+
+    it("accepts a plain path", function()
+      local ok, err = validate({ url = "/test" })
+      assert.is_nil(err)
+      assert.is_truthy(ok)
+    end)
+
+    it("accepts the root path", function()
+      local ok, err = validate({ url = "/" })
+      assert.is_nil(err)
+      assert.is_truthy(ok)
+    end)
+
+    it("accepts a path with a single placeholder", function()
+      local ok, err = validate({ url = "/baz/<bar>" })
+      assert.is_nil(err)
+      assert.is_truthy(ok)
+    end)
+
+    it("accepts a path with multiple placeholders", function()
+      local ok, err = validate({ url = "/foo/<a>/bar/<b>" })
+      assert.is_nil(err)
+      assert.is_truthy(ok)
+    end)
+
+    it("accepts RFC 3986 sub-delims and percent-encoded values", function()
+      local ok, err = validate({ url = "/foo%20bar/a,b;c=d" })
+      assert.is_nil(err)
+      assert.is_truthy(ok)
+    end)
+
+    it("rejects a path without a leading slash", function()
+      local ok, err = validate({ url = "new_url" })
+      assert.is_falsy(ok)
+      assert.matches("invalid path", err.config.url)
+    end)
+
+    it("rejects a path with a leading-slash-less placeholder", function()
+      local ok, err = validate({ url = "new_url/<bar>" })
+      assert.is_falsy(ok)
+      assert.matches("invalid path", err.config.url)
+    end)
+
+    it("rejects a full URL (does not start with a slash)", function()
+      local ok, err = validate({ url = "http://new-url.com" })
+      assert.is_falsy(ok)
+      assert.matches("invalid path", err.config.url)
+    end)
+
+    it("rejects characters outside the RFC 3986 reserved list", function()
+      local ok, err = validate({ url = "/foo bar" })
+      assert.is_falsy(ok)
+      assert.matches("invalid path", err.config.url)
+    end)
+
+    it("rejects malformed percent-encoding", function()
+      local ok, err = validate({ url = "/foo%2" })
+      assert.is_falsy(ok)
+      assert.matches("invalid url%-encoded value", err.config.url)
+    end)
+
+    it("is required", function()
+      local ok, err = validate({})
+      assert.is_falsy(ok)
+      assert.matches("required field missing", err.config.url)
+    end)
+
+  end)
+
+  describe("config.query_string", function()
+
+    it("accepts an array of strings alongside a valid url", function()
+      local ok, err = validate({
+        url = "/test",
+        query_string = { "code_parameter=<code_parameter>", "parameter2=abcdef" },
+      })
+      assert.is_nil(err)
+      assert.is_truthy(ok)
+    end)
+
+    it("is optional", function()
+      local ok, err = validate({ url = "/test" })
+      assert.is_nil(err)
+      assert.is_truthy(ok)
+    end)
+
+  end)
+
+end)


### PR DESCRIPTION
## What

Adds schema-level validation for the plugin's `config.url` and gives the
repository documentation/tooling a refresh.

### Schema
- `config.url` now uses a `custom_validator` mirroring Kong's own `validate_path`:
  the value must start with a forward slash (`/`) and may only contain characters
  from the RFC 3986 reserved list.
- `<param>` placeholders are substituted with a dummy segment before validation,
  so the existing templating syntax keeps working.
- Invalid rewrite targets are now rejected at configuration time instead of
  failing silently at request time.
- Adds unit tests covering valid paths, placeholders, percent-encoding and the
  rejected cases.

### Docs & tooling
- README: documents the `config.url` rules and `<capture>` placeholders, the
  optional `config.query_string` field, fixes the Admin API example to use the
  real plugin name (`url-rewrite`), and replaces the stale docker snippet with the
  docker-compose + Pongo flow.
- CONTRIBUTING: updated to the trunk-based flow, Pongo testing, and the
  squash/release-please + commitlint conventions.
- Adds `AGENTS.md` with repository-wide conventions (language, public-repo rules,
  Conventional Commits format, test naming).
- Makefile: fixes the `coverage` and `lint` targets, which referenced a
  non-existent folder, by routing them through Pongo.
- CI: the commitlint workflow referenced a `.commitlintrc.json` that did not exist,
  so the conventional-commits rules were never actually enforced. Adds the config
  (extending `@commitlint/config-conventional`) and bumps the action versions
  (`checkout` v2->v4, `commitlint-github-action` v1->v6).

## Breaking change

BREAKING CHANGE: `config.url` values that do not start with `/` are now rejected
by the schema. Existing configurations using a relative value must be updated.

## Testing

`make test` (Kong Pongo) — unit suite passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)